### PR TITLE
Update containers_logrotate.conf

### DIFF
--- a/templates/logrotate/containers_logrotate.conf.erb
+++ b/templates/logrotate/containers_logrotate.conf.erb
@@ -1,4 +1,4 @@
-/var/log/containers/*/*log /var/log/containers/*/*/*log /var/log/containers/*/*err {
+/var/log/containers/*/*[!healthcheck].log /var/log/containers/*/*/*log /var/log/containers/*/*err {
   <%= @rotation %>
   rotate <%= @rotate %>
   maxage <%= @purge_after_days %>


### PR DESCRIPTION
That minor change solves problem with /var/log/containers/stdouts/healthcheck.log issues. 
After rotating log is empty and json status is not added there.
That [!healthcheck] part prevents that log from rotating and status appears here correctly.